### PR TITLE
Add hangup function to Hikconnect API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ async with HikConnect() as api:
     # }
     # can be "idle" / "ringing" / "call in progress" - see hikconnect/api.py:45
     
+    # Unlock device
     await api.unlock(my_device_serial, 1)
+    
+    # Cancel call for device
+    await api.cancel_call(my_device_serial, 1)
 
     # call this periodically at least once per 30 mins!
     if api.is_refresh_login_needed():

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ async with HikConnect() as api:
     await api.unlock(my_device_serial, 1)
     
     # Cancel call for device
-    await api.cancel_call(my_device_serial, 1)
+    await api.cancel_call(my_device_serial)
 
     # call this periodically at least once per 30 mins!
     if api.is_refresh_login_needed():

--- a/hikconnect/api.py
+++ b/hikconnect/api.py
@@ -252,6 +252,22 @@ class HikConnect:
             "info": info,
         }
 
+    async def hangup(self, device_serial: str):
+        """
+        Send hangup request.
+
+        The `device_serial` parameter can be obtained from `get_devices()` and/or `get_cameras()`.
+        """
+        async with self.client.put(
+                f"{self.BASE_URL}/v3/devconfig/v1/call/{device_serial}/operation?cmdId=3&handler={self.client.FEATURE_CODE}"
+        ) as res:
+            res_json = await res.json()
+        log.debug("Got hangup response '%s'", res_json)
+        log.info(
+            "Hangup device '%s'",
+            device_serial
+        )
+
     @staticmethod
     def _decode_jwt_expiration(jwt):
         # decode JWT manually because of PyJWT version incompatibility with HomeAssistant

--- a/hikconnect/api.py
+++ b/hikconnect/api.py
@@ -252,19 +252,19 @@ class HikConnect:
             "info": info,
         }
 
-    async def hangup(self, device_serial: str):
+    async def cancel_call(self, device_serial: str):
         """
-        Send hangup request.
+        Send cancel call request.
 
         The `device_serial` parameter can be obtained from `get_devices()` and/or `get_cameras()`.
         """
         async with self.client.put(
-                f"{self.BASE_URL}/v3/devconfig/v1/call/{device_serial}/operation?cmdId=3&handler={self.client.FEATURE_CODE}"
+                f"{self.BASE_URL}/v3/devconfig/v1/call/{device_serial}/operation?cmdId=3"
         ) as res:
             res_json = await res.json()
-        log.debug("Got hangup response '%s'", res_json)
+        log.debug("Got cancel_call response '%s'", res_json)
         log.info(
-            "Hangup device '%s'",
+            "Cancel call to device '%s'",
             device_serial
         )
 

--- a/tests/test_manual.py
+++ b/tests/test_manual.py
@@ -32,6 +32,10 @@ async def test_main():
         print(f"api.unlock({devices[0]['serial']=}, {channel_number=})")
         # await api.unlock(devices[0]["serial"], channel_number)
 
+        # BEWARE: will actually hangup an active call!
+        print(f"api.hangup({devices[0]['serial']=})")
+        await api.hangup(devices[0]["serial"])
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)

--- a/tests/test_manual.py
+++ b/tests/test_manual.py
@@ -29,12 +29,12 @@ async def test_main():
         await api.refresh_login()
 
         # BEWARE: actually unlocks door!
-        print(f"api.unlock({devices[0]['serial']=}, {channel_number=})")
+        # print(f"api.unlock({devices[0]['serial']=}, {channel_number=})")
         # await api.unlock(devices[0]["serial"], channel_number)
 
         # BEWARE: will actually hangup an active call!
-        print(f"api.hangup({devices[0]['serial']=})")
-        await api.hangup(devices[0]["serial"])
+        # print(f"api.hangup({devices[0]['serial']=})")
+        # await api.cancel_call(devices[0]["serial"])
 
 
 if __name__ == "__main__":

--- a/tests/test_manual.py
+++ b/tests/test_manual.py
@@ -29,11 +29,11 @@ async def test_main():
         await api.refresh_login()
 
         # BEWARE: actually unlocks door!
-        # print(f"api.unlock({devices[0]['serial']=}, {channel_number=})")
+        print(f"api.unlock({devices[0]['serial']=}, {channel_number=})")
         # await api.unlock(devices[0]["serial"], channel_number)
 
-        # BEWARE: will actually hangup an active call!
-        # print(f"api.hangup({devices[0]['serial']=})")
+        # BEWARE: cancels an active call!
+        print(f"api.cancel_call({devices[0]['serial']=})")
         # await api.cancel_call(devices[0]["serial"])
 
 


### PR DESCRIPTION
A new asynchronous function 'hangup' was added to the hikconnect/api.py. The purpose of this function is to send a hangup request to a specific device, using the device's unique serial number.

PS: I'm a python newbie. I just used information available at [forum](https://community.home-assistant.io/t/ds-kd8003-ds-kv8113-ds-kv8213-ds-kv6113-ds-kv8413-and-integration-hikvision-hikconnect-video-intercom-doorbell/238535/1134) and implemented it by copying `unlock` function. I've tested it with my device, and it seems to work as expected.