### PR TITLE
Add automatic PyPI release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    environment: pypi
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Poetry
+        run: python -m pip install poetry
+
+      - name: Check tag matches package version
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          package_version="$(python -m poetry version --short)"
+          if [ "$tag_version" != "$package_version" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match pyproject.toml version $package_version" >&2
+            exit 1
+          fi
+
+      - name: Run unit tests
+        run: |
+          python -m poetry install
+          python -m poetry run pytest tests
+
+      - name: Build package
+        run: python -m poetry build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - '[0-9]*.[0-9]*.[0-9]*'
 
 jobs:
   release:
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so the version can be derived from the git tag
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -27,22 +29,18 @@ jobs:
       - name: Install Poetry
         run: python -m pip install poetry
 
-      - name: Check tag matches package version
-        run: |
-          tag_version="${GITHUB_REF_NAME#v}"
-          package_version="$(python -m poetry version --short)"
-          if [ "$tag_version" != "$package_version" ]; then
-            echo "Tag $GITHUB_REF_NAME does not match pyproject.toml version $package_version" >&2
-            exit 1
-          fi
-
       - name: Run unit tests
         run: |
           python -m poetry install
           python -m poetry run pytest tests
 
       - name: Build package
-        run: python -m poetry build
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: Check built version matches tag
+        run: ls "dist/hikconnect-${GITHUB_REF_NAME}.tar.gz" "dist/hikconnect-${GITHUB_REF_NAME}-py3-none-any.whl"
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 
 name = "hikconnect"
-version = "2.1.0"
+version = "0.0.0"  # placeholder - the real version is derived from the git tag, see [tool.poetry-dynamic-versioning]
 description = "Communicate with Hikvision smart doorbells via Hik-Connect cloud."
 
 license = "MIT"
@@ -68,7 +68,14 @@ pygments = "^2.18.0"
 
 target-version = ["py311"]
 
+[tool.poetry-dynamic-versioning]
+
+enable = true
+vcs = "git"
+style = "pep440"
+pattern = "default-unprefixed"  # tags are plain "1.2.3", without "v" prefix
+
 [build-system]
 
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"


### PR DESCRIPTION
Adds a `Release` workflow that publishes to PyPI automatically, with the package version derived from the git tag. New release flow — just one step:

1. Create a tag `X.Y.Z` (no `v` prefix) or a GitHub release — the workflow runs tests, builds, and uploads to PyPI. No version bump commit, no manual `make upload`.

How it works:

- `pyproject.toml` version is a `0.0.0` placeholder; the real version comes from the git tag via [poetry-dynamic-versioning](https://github.com/mtkennerly/poetry-dynamic-versioning) (`pattern = "default-unprefixed"` for plain `1.2.3` tags).
- The workflow triggers on `[0-9]*.[0-9]*.[0-9]*` tags, runs unit tests, builds via PEP 517 (`python -m build`, so no poetry plugin setup needed in CI), verifies the built artifacts match the tag, and publishes via PyPI trusted publishing (OIDC) — no API token stored.
- Verified locally: building at a test tag `9.9.9` produced `hikconnect-9.9.9.tar.gz` / `.whl`.

Notes:

- For local builds/`make upload` (manual fallback) to produce the right version, install the plugin once: `poetry self add "poetry-dynamic-versioning[plugin]"`. Without it, local builds are versioned `0.0.0` — harmless for development.
- Tags for past releases (0.6.0–2.1.0) should be pushed separately so the derived versions have history; releases 0.1.0–0.5.0 predate the git history and can't be tagged.